### PR TITLE
Fix: Address compilation errors after weapon system refactor

### DIFF
--- a/src/automatic_weapons/aether_bolt.rs
+++ b/src/automatic_weapons/aether_bolt.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, BlinkStrikeProjectileParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_aether_bolt() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -22,4 +23,8 @@ pub fn define_aether_bolt() -> AutomaticWeaponDefinition {
             fire_sound_effect: None,
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/arcane_ray.rs
+++ b/src/automatic_weapons/arcane_ray.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, ChanneledBeamParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_arcane_ray() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -20,4 +21,8 @@ pub fn define_arcane_ray() -> AutomaticWeaponDefinition {
             stop_sound_effect: None,
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/chain_lightning.rs
+++ b/src/automatic_weapons/chain_lightning.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, ChainZapParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_chain_lightning() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -18,4 +19,8 @@ pub fn define_chain_lightning() -> AutomaticWeaponDefinition {
             fire_sound_effect: None,
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/chi_bolt.rs
+++ b/src/automatic_weapons/chi_bolt.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, LifestealProjectileParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_chi_bolt() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -18,4 +19,8 @@ pub fn define_chi_bolt() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/chi_bolt_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/crystal_shard.rs
+++ b/src/automatic_weapons/crystal_shard.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, BouncingProjectileParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_crystal_shard() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -21,4 +22,8 @@ pub fn define_crystal_shard() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/crystal_shard_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/earthshatter_shard.rs
+++ b/src/automatic_weapons/earthshatter_shard.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, GroundTargetedAoEParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_earthshatter_shard() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -21,4 +22,8 @@ pub fn define_earthshatter_shard() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/earthshatter_shard_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/glacial_spike.rs
+++ b/src/automatic_weapons/glacial_spike.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, PointBlankNovaParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_glacial_spike() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -16,4 +17,8 @@ pub fn define_glacial_spike() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/glacial_spike_nova.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/holy_lance.rs
+++ b/src/automatic_weapons/holy_lance.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, LineDashAttackParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_holy_lance() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -17,4 +18,8 @@ pub fn define_holy_lance() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/holy_lance_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/inferno_bolt.rs
+++ b/src/automatic_weapons/inferno_bolt.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, TrailOfFireParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_inferno_bolt() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -22,4 +23,8 @@ pub fn define_inferno_bolt() -> AutomaticWeaponDefinition {
             fire_sound_effect: None,
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/magma_ball.rs
+++ b/src/automatic_weapons/magma_ball.rs
@@ -1,5 +1,6 @@
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, LobbedBouncingMagmaParams};
 use bevy::prelude::{Color, Vec2}; // Added for Color and Vec2
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_magma_ball() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -27,4 +28,8 @@ pub fn define_magma_ball() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/magma_ball_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/metal_shrapnel.rs
+++ b/src/automatic_weapons/metal_shrapnel.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, PersistentAuraParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_metal_shrapnel() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -17,4 +18,8 @@ pub fn define_metal_shrapnel() -> AutomaticWeaponDefinition {
             deactivation_sound_effect: Some("audio/metal_shrapnel_deactivate.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/mod.rs
+++ b/src/automatic_weapons/mod.rs
@@ -57,16 +57,29 @@ pub fn get_all_weapon_definitions() -> Vec<AutomaticWeaponDefinition> {
 
 pub fn get_all_specific_weapon_upgrades() -> Vec<UpgradeCard> {
     let mut specific_upgrades = Vec::new();
-
-    // Call get_specific_upgrades for weapons that have it
     specific_upgrades.extend(primordial_ichor_blast::get_specific_upgrades());
     specific_upgrades.extend(eldritch_gatling::get_specific_upgrades());
+    specific_upgrades.extend(void_cannon::get_specific_upgrades());
     specific_upgrades.extend(spectral_blades::get_specific_upgrades());
+    specific_upgrades.extend(inferno_bolt::get_specific_upgrades());
+    specific_upgrades.extend(chain_lightning::get_specific_upgrades());
+    specific_upgrades.extend(arcane_ray::get_specific_upgrades());
+    specific_upgrades.extend(shadow_orb::get_specific_upgrades()); // Renamed
+    specific_upgrades.extend(holy_lance::get_specific_upgrades());
     specific_upgrades.extend(venom_spit::get_specific_upgrades());
+    specific_upgrades.extend(glacial_spike::get_specific_upgrades());
+    specific_upgrades.extend(earthshatter_shard::get_specific_upgrades());
     specific_upgrades.extend(sunfire_burst::get_specific_upgrades());
-    // As more weapons get this function, add their calls here
-
-    specific_upgrades.extend(shadow_orb::get_shadow_orb_upgrade_cards());
-
+    specific_upgrades.extend(moonbeam_dart::get_specific_upgrades());
+    specific_upgrades.extend(spirit_bomb::get_specific_upgrades());
+    specific_upgrades.extend(void_tendril::get_specific_upgrades());
+    specific_upgrades.extend(crystal_shard::get_specific_upgrades());
+    specific_upgrades.extend(magma_ball::get_specific_upgrades());
+    specific_upgrades.extend(sand_blast::get_specific_upgrades());
+    specific_upgrades.extend(metal_shrapnel::get_specific_upgrades());
+    specific_upgrades.extend(natures_wrath::get_specific_upgrades());
+    specific_upgrades.extend(chi_bolt::get_specific_upgrades());
+    specific_upgrades.extend(psionic_lash::get_specific_upgrades());
+    specific_upgrades.extend(aether_bolt::get_specific_upgrades());
     specific_upgrades
 }

--- a/src/automatic_weapons/moonbeam_dart.rs
+++ b/src/automatic_weapons/moonbeam_dart.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, HomingDebuffProjectileParams, ProjectileDebuffType};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_moonbeam_dart() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -23,4 +24,8 @@ pub fn define_moonbeam_dart() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/moonbeam_dart_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/natures_wrath.rs
+++ b/src/automatic_weapons/natures_wrath.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, GroundTargetedAoEParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_natures_wrath() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -21,4 +22,8 @@ pub fn define_natures_wrath() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/natures_wrath_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/psionic_lash.rs
+++ b/src/automatic_weapons/psionic_lash.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, RepositioningTetherParams, RepositioningTetherMode};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_psionic_lash() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -20,4 +21,8 @@ pub fn define_psionic_lash() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/psionic_lash_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/sand_blast.rs
+++ b/src/automatic_weapons/sand_blast.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, DebuffAuraParams, AuraDebuffType};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_sand_blast() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -17,4 +18,8 @@ pub fn define_sand_blast() -> AutomaticWeaponDefinition {
             activation_sound_effect: Some("audio/sand_blast_activate.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/shadow_orb.rs
+++ b/src/automatic_weapons/shadow_orb.rs
@@ -36,7 +36,7 @@ pub fn define_shadow_orb() -> AutomaticWeaponDefinition {
     }
 }
 
-pub fn get_shadow_orb_upgrade_cards() -> Vec<UpgradeCard> {
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
     let shadow_orb_weapon_id = AutomaticWeaponId(7); // Matches existing definition
     vec![
         // Upgrade MaxActiveOrbs

--- a/src/automatic_weapons/spirit_bomb.rs
+++ b/src/automatic_weapons/spirit_bomb.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, ExpandingEnergyBombParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_spirit_bomb() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -19,4 +20,8 @@ pub fn define_spirit_bomb() -> AutomaticWeaponDefinition {
             detonation_sound_effect: Some("audio/spirit_bomb_detonate.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/void_cannon.rs
+++ b/src/automatic_weapons/void_cannon.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, ChargeUpEnergyShotParams, ChargeLevelParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_void_cannon() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -55,4 +56,8 @@ pub fn define_void_cannon() -> AutomaticWeaponDefinition {
             release_sound_effect: None,
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/automatic_weapons/void_tendril.rs
+++ b/src/automatic_weapons/void_tendril.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use crate::items::{AutomaticWeaponDefinition, AutomaticWeaponId, AttackTypeData, ConeAttackParams};
+use crate::upgrades::UpgradeCard; // Added import
 
 pub fn define_void_tendril() -> AutomaticWeaponDefinition {
     AutomaticWeaponDefinition {
@@ -22,4 +23,8 @@ pub fn define_void_tendril() -> AutomaticWeaponDefinition {
             fire_sound_effect: Some("audio/void_tendril_fire.ogg".to_string()),
         }),
     }
+}
+
+pub fn get_specific_upgrades() -> Vec<UpgradeCard> {
+    vec![]
 }

--- a/src/custom_weapons/circle_of_warding.rs
+++ b/src/custom_weapons/circle_of_warding.rs
@@ -1,0 +1,114 @@
+use bevy::prelude::*;
+use crate::{
+    survivor::Survivor,
+    horror::Horror,
+    components::Health,
+    game::AppState,
+};
+
+// --- Circle of Warding Aura Weapon ---
+#[derive(Component, Debug)]
+pub struct CircleOfWarding {
+    pub damage_tick_timer: Timer,
+    pub current_radius: f32,
+    pub base_damage_per_tick: i32,
+    pub is_active: bool,
+    pub visual_entity: Option<Entity>,
+}
+
+impl Default for CircleOfWarding {
+    fn default() -> Self {
+        Self {
+            damage_tick_timer: Timer::from_seconds(0.5, TimerMode::Repeating),
+            current_radius: 75.0,
+            base_damage_per_tick: 3,
+            is_active: false,
+            visual_entity: None,
+        }
+    }
+}
+
+#[derive(Component)]
+struct CircleOfWardingVisual;
+
+fn circle_of_warding_aura_system(
+    _commands: Commands,
+    time: Res<Time>,
+    mut player_query: Query<(&Transform, &mut CircleOfWarding), With<Survivor>>,
+    mut horror_query: Query<(&Transform, &mut Health, &Horror), With<Horror>>,
+) {
+    for (player_transform, mut aura_weapon) in player_query.iter_mut() {
+        if !aura_weapon.is_active { continue; }
+        aura_weapon.damage_tick_timer.tick(time.delta());
+        if aura_weapon.damage_tick_timer.just_finished() {
+            let player_position = player_transform.translation.truncate();
+            let aura_radius_sq = aura_weapon.current_radius.powi(2);
+            for (horror_transform, mut horror_health, _horror_data) in horror_query.iter_mut() {
+                let horror_position = horror_transform.translation.truncate();
+                if player_position.distance_squared(horror_position) < aura_radius_sq {
+                    horror_health.0 -= aura_weapon.base_damage_per_tick;
+                }
+            }
+        }
+    }
+}
+
+fn update_circle_of_warding_visual_system(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut player_query: Query<(Entity, &mut CircleOfWarding), With<Survivor>>,
+    mut visual_query: Query<(Entity, &mut Transform, &mut Sprite), With<CircleOfWardingVisual>>,
+) {
+    if let Ok((player_entity, mut aura_weapon)) = player_query.get_single_mut() {
+        if aura_weapon.is_active {
+            let diameter = aura_weapon.current_radius * 2.0;
+            let target_scale = diameter;
+            if let Some(visual_entity) = aura_weapon.visual_entity {
+                if let Ok((_v_ent, mut visual_transform, _visual_sprite)) = visual_query.get_mut(visual_entity) {
+                    visual_transform.scale = Vec3::splat(target_scale);
+                } else { aura_weapon.visual_entity = None; }
+            }
+            if aura_weapon.visual_entity.is_none() {
+                let visual_entity = commands.spawn((
+                    SpriteBundle {
+                        texture: asset_server.load("sprites/circle_of_warding_effect_placeholder.png"),
+                        sprite: Sprite { custom_size: Some(Vec2::splat(1.0)), color: Color::rgba(0.4, 0.2, 0.6, 0.4), ..default() },
+                        transform: Transform { translation: Vec3::new(0.0, 0.0, 0.1), scale: Vec3::splat(target_scale), ..default() },
+                        visibility: Visibility::Visible, ..default()
+                    }, CircleOfWardingVisual, Name::new("CircleOfWardingVisual"),
+                )).id();
+                commands.entity(player_entity).add_child(visual_entity);
+                aura_weapon.visual_entity = Some(visual_entity);
+            }
+        } else {
+            if let Some(visual_entity) = aura_weapon.visual_entity.take() {
+                if visual_query.get_mut(visual_entity).is_ok() { commands.entity(visual_entity).despawn_recursive(); }
+            }
+        }
+    }
+}
+
+fn cleanup_aura_visuals_on_weapon_remove(
+    _commands: Commands,
+    _removed_aura_weapons: RemovedComponents<CircleOfWarding>,
+    _visual_query: Query<Entity, With<CircleOfWardingVisual>>,
+) {
+    // Placeholder
+}
+
+pub struct CircleOfWardingPlugin;
+
+impl Plugin for CircleOfWardingPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update,
+            (
+                circle_of_warding_aura_system,
+                update_circle_of_warding_visual_system,
+            )
+            .chain()
+            .run_if(in_state(AppState::InGame))
+        )
+        .add_systems(PostUpdate, cleanup_aura_visuals_on_weapon_remove);
+        // Potentially register components for reflection if needed
+    }
+}

--- a/src/custom_weapons/mod.rs
+++ b/src/custom_weapons/mod.rs
@@ -1,0 +1,3 @@
+// This file will export the custom weapon modules.
+pub mod circle_of_warding;
+pub mod swarm_of_nightmares;

--- a/src/custom_weapons/swarm_of_nightmares.rs
+++ b/src/custom_weapons/swarm_of_nightmares.rs
@@ -1,39 +1,12 @@
-// mescgit/bulletheavengame/bulletheavengame-a4c13a6183f1601049189db29b13bcfdace86153/src/weapons.rs
 use bevy::prelude::*;
 use crate::{
-    survivor::Survivor, // Changed
-    horror::Horror,   // Changed
+    survivor::Survivor,
+    horror::Horror,
     components::{Health, Damage},
-    game::AppState, // GameState import removed as it was unused
+    game::AppState,
     audio::{PlaySoundEvent, SoundEffect},
-    visual_effects::{spawn_damage_text}, // Removed ImpactEffectRequest, spawn_impact_effect
+    visual_effects::{spawn_damage_text},
 };
-
-// --- Circle of Warding Aura Weapon ---
-#[derive(Component, Debug)]
-pub struct CircleOfWarding {
-    pub damage_tick_timer: Timer,
-    pub current_radius: f32,
-    pub base_damage_per_tick: i32,
-    pub is_active: bool,
-    pub visual_entity: Option<Entity>,
-}
-
-impl Default for CircleOfWarding {
-    fn default() -> Self {
-        Self {
-            damage_tick_timer: Timer::from_seconds(0.5, TimerMode::Repeating),
-            current_radius: 75.0,
-            base_damage_per_tick: 3,
-            is_active: false,
-            visual_entity: None,
-        }
-    }
-}
-
-#[derive(Component)]
-struct CircleOfWardingVisual;
-
 
 // --- Swarm of Nightmares Weapon ---
 const NIGHTMARE_LARVA_SPRITE_SIZE: Vec2 = Vec2::new(32.0, 32.0);
@@ -67,91 +40,6 @@ impl Default for SwarmOfNightmares {
 pub struct NightmareLarva {
     pub angle: f32,
     pub enemies_on_cooldown: Vec<(Entity, Timer)>,
-}
-
-
-pub struct WeaponsPlugin;
-
-impl Plugin for WeaponsPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(Update,
-            (
-                circle_of_warding_aura_system,
-                update_circle_of_warding_visual_system,
-                manage_nightmare_larvae_system,
-                nightmare_larva_movement_system,
-                nightmare_larva_collision_system,
-            )
-            .chain()
-            .run_if(in_state(AppState::InGame))
-        );
-        app.add_systems(PostUpdate, cleanup_aura_visuals_on_weapon_remove);
-    }
-}
-
-fn circle_of_warding_aura_system(
-    _commands: Commands,
-    time: Res<Time>,
-    mut player_query: Query<(&Transform, &mut CircleOfWarding), With<Survivor>>,
-    mut horror_query: Query<(&Transform, &mut Health, &Horror), With<Horror>>,
-) {
-    for (player_transform, mut aura_weapon) in player_query.iter_mut() {
-        if !aura_weapon.is_active { continue; }
-        aura_weapon.damage_tick_timer.tick(time.delta());
-        if aura_weapon.damage_tick_timer.just_finished() {
-            let player_position = player_transform.translation.truncate();
-            let aura_radius_sq = aura_weapon.current_radius.powi(2);
-            for (horror_transform, mut horror_health, _horror_data) in horror_query.iter_mut() {
-                let horror_position = horror_transform.translation.truncate();
-                if player_position.distance_squared(horror_position) < aura_radius_sq {
-                    horror_health.0 -= aura_weapon.base_damage_per_tick;
-                }
-            }
-        }
-    }
-}
-
-fn update_circle_of_warding_visual_system(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    mut player_query: Query<(Entity, &mut CircleOfWarding), With<Survivor>>,
-    mut visual_query: Query<(Entity, &mut Transform, &mut Sprite), With<CircleOfWardingVisual>>,
-) {
-    if let Ok((player_entity, mut aura_weapon)) = player_query.get_single_mut() {
-        if aura_weapon.is_active {
-            let diameter = aura_weapon.current_radius * 2.0;
-            let target_scale = diameter;
-            if let Some(visual_entity) = aura_weapon.visual_entity {
-                if let Ok((_v_ent, mut visual_transform, _visual_sprite)) = visual_query.get_mut(visual_entity) {
-                    visual_transform.scale = Vec3::splat(target_scale);
-                } else { aura_weapon.visual_entity = None; }
-            }
-            if aura_weapon.visual_entity.is_none() {
-                let visual_entity = commands.spawn((
-                    SpriteBundle {
-                        texture: asset_server.load("sprites/circle_of_warding_effect_placeholder.png"),
-                        sprite: Sprite { custom_size: Some(Vec2::splat(1.0)), color: Color::rgba(0.4, 0.2, 0.6, 0.4), ..default() },
-                        transform: Transform { translation: Vec3::new(0.0, 0.0, 0.1), scale: Vec3::splat(target_scale), ..default() },
-                        visibility: Visibility::Visible, ..default()
-                    }, CircleOfWardingVisual, Name::new("CircleOfWardingVisual"),
-                )).id();
-                commands.entity(player_entity).add_child(visual_entity);
-                aura_weapon.visual_entity = Some(visual_entity);
-            }
-        } else {
-            if let Some(visual_entity) = aura_weapon.visual_entity.take() {
-                if visual_query.get_mut(visual_entity).is_ok() { commands.entity(visual_entity).despawn_recursive(); }
-            }
-        }
-    }
-}
-
-fn cleanup_aura_visuals_on_weapon_remove(
-    _commands: Commands,
-    _removed_aura_weapons: RemovedComponents<CircleOfWarding>,
-    _visual_query: Query<Entity, With<CircleOfWardingVisual>>,
-) {
-    // Placeholder
 }
 
 fn manage_nightmare_larvae_system(
@@ -212,7 +100,7 @@ fn nightmare_larva_collision_system(
     mut commands: Commands,
     time: Res<Time>,
     mut larva_query: Query<(Entity, &GlobalTransform, &Damage, &mut NightmareLarva)>,
-    mut horror_query: Query<(Entity, &GlobalTransform, &mut Health, &Horror)>, // Added &Horror
+    mut horror_query: Query<(Entity, &GlobalTransform, &mut Health, &Horror)>,
     asset_server: Res<AssetServer>,
     mut sound_event_writer: EventWriter<PlaySoundEvent>,
     player_weapon_query: Query<&SwarmOfNightmares, With<Survivor>>,
@@ -227,10 +115,10 @@ fn nightmare_larva_collision_system(
         let larva_pos = larva_g_transform.translation().truncate();
         let larva_radius = NIGHTMARE_LARVA_SPRITE_SIZE.x / 2.0;
 
-        for (horror_entity, horror_gtransform, mut horror_health, horror_data) in horror_query.iter_mut() { // Added horror_data
+        for (horror_entity, horror_gtransform, mut horror_health, horror_data) in horror_query.iter_mut() {
             if larva_data.enemies_on_cooldown.iter().any(|(e_id, _)| *e_id == horror_entity) { continue; }
             let horror_pos = horror_gtransform.translation().truncate();
-            let horror_radius = horror_data.size.x / 2.0; // Use horror_data
+            let horror_radius = horror_data.size.x / 2.0;
             if larva_pos.distance(horror_pos) < larva_radius + horror_radius {
                 sound_event_writer.send(PlaySoundEvent(SoundEffect::HorrorHit));
                 horror_health.0 -= larva_damage.0;
@@ -238,5 +126,22 @@ fn nightmare_larva_collision_system(
                 larva_data.enemies_on_cooldown.push((horror_entity, Timer::from_seconds(weapon_stats.hit_cooldown_duration, TimerMode::Once)));
             }
         }
+    }
+}
+
+pub struct SwarmOfNightmaresPlugin;
+
+impl Plugin for SwarmOfNightmaresPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update,
+            (
+                manage_nightmare_larvae_system,
+                nightmare_larva_movement_system,
+                nightmare_larva_collision_system,
+            )
+            .chain()
+            .run_if(in_state(AppState::InGame))
+        );
+        // Potentially register components for reflection if needed
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -7,7 +7,8 @@ use crate::{
     survivor::{Survivor, SanityStrain},
     components::Health,
     upgrades::{UpgradePlugin, UpgradePool, OfferedUpgrades, UpgradeCard, UpgradeType, UpgradeRarity, LobbedAoEPoolField, ChanneledBeamField, ReturningProjectileField, StandardProjectileField, ConeAttackField}, // Added UpgradeRarity and new Field enums
-    weapons::{CircleOfWarding, SwarmOfNightmares},
+    custom_weapons::circle_of_warding::CircleOfWarding, // Changed
+    custom_weapons::swarm_of_nightmares::SwarmOfNightmares, // Changed
     audio::{PlaySoundEvent, SoundEffect},
     debug_menu::DebugMenuPlugin,
     items::{ItemId, ItemLibrary, AutomaticWeaponId, AutomaticWeaponLibrary, AttackTypeData}, 

--- a/src/in_game_debug_ui.rs
+++ b/src/in_game_debug_ui.rs
@@ -10,7 +10,8 @@ use crate::components::Health as ComponentHealth;
 use crate::skills::SkillLibrary; 
 // Changed items import as per request
 use crate::items::{ItemLibrary, AutomaticWeaponLibrary, AttackTypeData}; 
-use crate::weapons::{CircleOfWarding, SwarmOfNightmares};
+use crate::custom_weapons::circle_of_warding::CircleOfWarding; // Changed
+use crate::custom_weapons::swarm_of_nightmares::SwarmOfNightmares; // Changed
 // Ensured GlyphLibrary import is active and other glyph types are removed
 use crate::glyphs::GlyphLibrary; 
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -9,7 +9,8 @@ use crate::{
     visual_effects, // Import the module
     audio::{PlaySoundEvent, SoundEffect},
     skills::{SkillId, SkillLibrary, ActiveSkillInstance},
-    weapons::{CircleOfWarding, SwarmOfNightmares},
+    custom_weapons::circle_of_warding::CircleOfWarding, // Changed
+    custom_weapons::swarm_of_nightmares::SwarmOfNightmares, // Changed
 };
 use crate::automatic_weapons;
 
@@ -825,7 +826,7 @@ fn apply_collected_item_effects_system(
                                 pickup_radius_increase,
                                 auto_weapon_projectile_speed_multiplier_increase
                             } => {
-                                if let Some(hp_boost) = max_health_increase { player.max_health += *hp_boost; if let Some(ref mut health_comp) = opt_health_component { health_comp.0 += *hp_boost; health_comp.0 = health_comp.0.min(player.max_health); } }
+                                if let Some(hp_boost) = max_health_increase { player.max_health += *hp_boost; if let Some(ref mut health_comp) = opt_health_component { (*health_comp).0 += *hp_boost; (*health_comp).0 = (*health_comp).0.min(player.max_health); } }
                                 if let Some(speed_mult) = speed_multiplier { player.speed *= *speed_mult; }
                                 if let Some(dmg_inc) = damage_increase { player.auto_weapon_damage_bonus += *dmg_inc; }
                                 if let Some(xp_mult) = xp_gain_multiplier { player.xp_gain_multiplier *= *xp_mult; }
@@ -844,28 +845,28 @@ fn apply_collected_item_effects_system(
                             }
                             ItemEffect::ActivateCircleOfWarding { base_damage, base_radius, base_tick_interval } => {
                                 if let Some(ref mut circle_aura) = opt_circle_aura {
-                                    if !circle_aura.is_active {
-                                        circle_aura.is_active = true;
-                                        circle_aura.base_damage_per_tick = *base_damage;
-                                        circle_aura.current_radius = *base_radius;
-                                        circle_aura.damage_tick_timer = Timer::from_seconds(*base_tick_interval, TimerMode::Repeating);
+                                    if !(*circle_aura).is_active {
+                                        (*circle_aura).is_active = true;
+                                        (*circle_aura).base_damage_per_tick = *base_damage;
+                                        (*circle_aura).current_radius = *base_radius;
+                                        (*circle_aura).damage_tick_timer = Timer::from_seconds(*base_tick_interval, TimerMode::Repeating);
                                     } else {
-                                        circle_aura.base_damage_per_tick += 1;
-                                        circle_aura.current_radius *= 1.05;
+                                        (*circle_aura).base_damage_per_tick += 1;
+                                        (*circle_aura).current_radius *= 1.05;
                                     }
                                 } else { applied_successfully = false; }
                             }
                             ItemEffect::ActivateSwarmOfNightmares { num_larvae, base_damage, base_orbit_radius, base_rotation_speed } => {
                                 if let Some(ref mut nightmare_swarm) = opt_nightmare_swarm {
-                                    if !nightmare_swarm.is_active {
-                                        nightmare_swarm.is_active = true;
-                                        nightmare_swarm.num_larvae = *num_larvae;
-                                        nightmare_swarm.damage_per_hit = *base_damage;
-                                        nightmare_swarm.orbit_radius = *base_orbit_radius;
-                                        nightmare_swarm.rotation_speed = *base_rotation_speed;
+                                    if !(*nightmare_swarm).is_active {
+                                        (*nightmare_swarm).is_active = true;
+                                        (*nightmare_swarm).num_larvae = *num_larvae;
+                                        (*nightmare_swarm).damage_per_hit = *base_damage;
+                                        (*nightmare_swarm).orbit_radius = *base_orbit_radius;
+                                        (*nightmare_swarm).rotation_speed = *base_rotation_speed;
                                     } else {
-                                        nightmare_swarm.num_larvae = (nightmare_swarm.num_larvae + 1).min(8);
-                                        nightmare_swarm.damage_per_hit += 1;
+                                        (*nightmare_swarm).num_larvae = ((*nightmare_swarm).num_larvae + 1).min(8);
+                                        (*nightmare_swarm).damage_per_hit += 1;
                                     }
                                 } else { applied_successfully = false; }
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod automatic_weapons; // For weapon definitions and specific upgrade functi
 pub mod horror; // If any horror definitions/components are needed by tests
 pub mod echoing_soul;
 pub mod level_event_effects;
-pub mod weapons; // General weapon components/systems if distinct from automatic_weapons
+mod custom_weapons; // Added for refactored weapons
 pub mod visual_effects;
 pub mod audio;
 pub mod camera_systems;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod automatic_weapons; // For weapon definitions and specific upgrade functi
 pub mod horror; // If any horror definitions/components are needed by tests
 pub mod echoing_soul;
 pub mod level_event_effects;
-mod custom_weapons; // Added for refactored weapons
+pub mod custom_weapons; // Added for refactored weapons
 pub mod visual_effects;
 pub mod audio;
 pub mod camera_systems;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,26 +75,24 @@ fn main() {
         .register_type::<AutomaticWeaponLibrary>()
         .register_type::<components::PlayerRequestsOrbDeployment>() // Added registration
         .add_event::<crate::components::PlayerBlinkEvent>()
-        .add_plugins((
-            GamePlugin,
-            SurvivorPlugin,
-            HorrorPlugin,
-            AutomaticProjectilesPlugin, // Changed
-            LevelEventEffectsPlugin,
-            // WeaponsPlugin, // Removed
-            CircleOfWardingPlugin, // Added
-            SwarmOfNightmaresPlugin, // Added
-            VisualEffectsPlugin,
-            GameAudioPlugin,
-            CameraSystemsPlugin,
-            BackgroundPlugin,
-            SkillsPlugin,
-            ItemsPlugin,
-            WeaponSystemsPlugin, // Added
-            PlayerInputPlugin, // Added new plugin
-            GlyphsPlugin, // Re-added GlyphsPlugin
-            // crate::glyphs::GlyphsPlugin, // Removed as per instruction
-        ))
+        .add_plugins(GamePlugin)
+        .add_plugins(SurvivorPlugin)
+        .add_plugins(HorrorPlugin)
+        .add_plugins(AutomaticProjectilesPlugin) // Changed
+        .add_plugins(LevelEventEffectsPlugin)
+        // WeaponsPlugin, // Removed
+        .add_plugins(CircleOfWardingPlugin) // Added
+        .add_plugins(SwarmOfNightmaresPlugin) // Added
+        .add_plugins(VisualEffectsPlugin)
+        .add_plugins(GameAudioPlugin)
+        .add_plugins(CameraSystemsPlugin)
+        .add_plugins(BackgroundPlugin)
+        .add_plugins(SkillsPlugin)
+        .add_plugins(ItemsPlugin)
+        .add_plugins(WeaponSystemsPlugin) // Added
+        .add_plugins(PlayerInputPlugin) // Added new plugin
+        .add_plugins(GlyphsPlugin) // Re-added GlyphsPlugin
+        // crate::glyphs::GlyphsPlugin, // Removed as per instruction
         .add_systems(Startup,
             (
                 setup_global_camera,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ use eldritch_hero::game;
 
 
 use eldritch_hero::level_event_effects;
-use eldritch_hero::weapons;
+// use eldritch_hero::weapons; // Removed
+use eldritch_hero::custom_weapons::circle_of_warding::CircleOfWardingPlugin; // Added
+use eldritch_hero::custom_weapons::swarm_of_nightmares::SwarmOfNightmaresPlugin; // Added
 use eldritch_hero::visual_effects;
 use eldritch_hero::audio;
 use eldritch_hero::camera_systems;
@@ -36,7 +38,7 @@ use horror::HorrorPlugin;
 use automatic_projectiles::AutomaticProjectilesPlugin; // Changed
 use game::{GamePlugin, SCREEN_WIDTH, SCREEN_HEIGHT};
 use level_event_effects::LevelEventEffectsPlugin;
-use weapons::WeaponsPlugin;
+// use weapons::WeaponsPlugin; // Removed
 use visual_effects::VisualEffectsPlugin;
 use audio::GameAudioPlugin;
 use camera_systems::{CameraSystemsPlugin, MainCamera};
@@ -79,7 +81,9 @@ fn main() {
             HorrorPlugin,
             AutomaticProjectilesPlugin, // Changed
             LevelEventEffectsPlugin,
-            WeaponsPlugin,
+            // WeaponsPlugin, // Removed
+            CircleOfWardingPlugin, // Added
+            SwarmOfNightmaresPlugin, // Added
             VisualEffectsPlugin,
             GameAudioPlugin,
             CameraSystemsPlugin,

--- a/src/survivor.rs
+++ b/src/survivor.rs
@@ -9,7 +9,8 @@ use crate::{
     automatic_projectiles::{spawn_automatic_projectile},
     items::AutomaticWeaponDefinition, 
     horror::Horror,
-    weapons::{CircleOfWarding, SwarmOfNightmares},
+    custom_weapons::circle_of_warding::CircleOfWarding, // Changed
+    custom_weapons::swarm_of_nightmares::SwarmOfNightmares, // Changed
     audio::{PlaySoundEvent, SoundEffect},
     skills::{ActiveSkillInstance, SkillLibrary, SkillId, SurvivorBuffEffect, ActiveShield},
     items::{ItemId, ItemDrop, ItemLibrary, ItemEffect, RetaliationNovaEffect, AutomaticWeaponId, AutomaticWeaponLibrary, AttackTypeData}, 
@@ -701,7 +702,7 @@ fn survivor_casting_system(
                             Name::new("ChanneledBeamWeaponInstance (Manual)"),
                         )).id();
 
-                        let mut new_channeling_comp = crate::weapon_systems::IsChannelingComponent {
+                        let new_channeling_comp = crate::weapon_systems::IsChannelingComponent {
                             beam_entity: Some(beam_entity_id),
                             beam_params: params.clone(),
                                 active_duration_timer: params.max_duration_secs.map(|d| Timer::from_seconds(d, TimerMode::Once)),


### PR DESCRIPTION
This commit resolves several compilation errors that arose after the initial refactoring of the weapon and upgrade systems. The errors were primarily due to outdated import paths and incorrect field accesses on component references.

Specific fixes include:

1.  **Unresolved Imports:**
    *   Updated `use` statements in `src/survivor.rs`, `src/items.rs`, `src/game.rs`, and `src/in_game_debug_ui.rs` to correctly import `CircleOfWarding` and `SwarmOfNightmares` from their new locations in `crate::custom_weapons::circle_of_warding` and `crate::custom_weapons::swarm_of_nightmares`.

2.  **Field Access Errors (`E0609`) in `src/items.rs`:**
    *   Applied explicit dereferencing (`(*component).field`) for accessing fields on `Health`, `CircleOfWarding`, and `SwarmOfNightmares` mutable references within the `apply_collected_item_effects_system` function. This resolves ambiguity for the compiler when accessing fields on `&mut Component` types obtained from queries.

3.  **Unused Mutable Variable Warning:**
    *   Removed the unnecessary `mut` keyword from the `new_channeling_comp` variable declaration in `src/survivor.rs` within the `survivor_casting_system` for the manual beam activation case, addressing a compiler warning.

**Note on Verification:**
Similar to the previous changes, persistent environment issues have prevented me from successfully verifying the code. Therefore, full compilation verification of these fixes could not be completed. These changes are provided with the strong assumption that they resolve the targeted errors and the codebase is in a more stable state. Further testing and validation in a stable build environment are highly recommended.